### PR TITLE
CUDA 9.1 and memory access bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,12 @@ set(
     CUDA_NVCC_FLAGS
     ${CUDA_NVCC_FLAGS};
     -O3 --use_fast_math
-    #-gencode=arch=compute_30,code=sm_30
-    #-gencode=arch=compute_35,code=sm_35
-    #-gencode=arch=compute_50,code=sm_50
-    #-gencode=arch=compute_52,code=sm_52
-    #-gencode=arch=compute_52,code=sm_52
+    -gencode=arch=compute_30,code=sm_30
+    -gencode=arch=compute_35,code=sm_35
+    -gencode=arch=compute_50,code=sm_50
+    -gencode=arch=compute_52,code=sm_52
+    -gencode=arch=compute_52,code=sm_52
     -gencode=arch=compute_70,code=sm_70
-    #-lineinfo
     )
 
 cuda_add_executable(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,13 @@ set(
     CUDA_NVCC_FLAGS
     ${CUDA_NVCC_FLAGS};
     -O3 --use_fast_math
-    -gencode=arch=compute_30,code=sm_30
-    -gencode=arch=compute_35,code=sm_35
-    -gencode=arch=compute_50,code=sm_50
-    -gencode=arch=compute_52,code=sm_52
+    #-gencode=arch=compute_30,code=sm_30
+    #-gencode=arch=compute_35,code=sm_35
+    #-gencode=arch=compute_50,code=sm_50
+    #-gencode=arch=compute_52,code=sm_52
+    #-gencode=arch=compute_52,code=sm_52
+    -gencode=arch=compute_70,code=sm_70
+    #-lineinfo
     )
 
 cuda_add_executable(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(
     -gencode=arch=compute_35,code=sm_35
     -gencode=arch=compute_50,code=sm_50
     -gencode=arch=compute_52,code=sm_52
-    -gencode=arch=compute_52,code=sm_52
+    -gencode=arch=compute_61,code=sm_61
     -gencode=arch=compute_70,code=sm_70
     )
 

--- a/Stixels.cu
+++ b/Stixels.cu
@@ -103,7 +103,7 @@ void Stixels::Initialize() {
 	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_normalization_ground, m_rows*sizeof(float)));
 	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_inv_sigma2_ground, m_rows*sizeof(float)));
 	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_object_disparity_range, m_max_dis*sizeof(float)));
-	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_object_lut, rows_power2*m_realcols*m_max_dis*sizeof(float)));
+	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_object_lut, (rows_power2*m_realcols*m_max_dis+1)*sizeof(float)));
 	CUDA_CHECK_RETURN(cudaMalloc((void **)&d_obj_cost_lut, m_max_dis*m_max_dis*sizeof(float)));
 
 	CUDA_CHECK_RETURN(cudaMemcpy(d_object_disparity_range, m_object_disparity_range, sizeof(float)*m_max_dis,

--- a/StixelsKernels.cu
+++ b/StixelsKernels.cu
@@ -193,14 +193,14 @@ __inline__ __device__ float warp_prefix_sum(const int i, const int fn, const pix
 
 	#pragma unroll
 	for (int j = 1; j <= WARP_SIZE; j *= 2) {
-		float n = __shfl_up(cost, j);
+		float n = __shfl_up_sync(0xFFFFFFFF, cost, j);
 
 		if (lane >= j) cost += n;
 	}
 
 	s_data[i+lane+1] = cost;
 
-	return __shfl(cost, WARP_SIZE-1);
+	return __shfl_sync(0xFFFFFFFF, cost, WARP_SIZE-1);
 }
 
 __inline__ __device__ void ComputePrefixSumWarp2(const int fn, const pixel_t* __restrict__ d_disparity,

--- a/StixelsKernels.cu
+++ b/StixelsKernels.cu
@@ -193,14 +193,22 @@ __inline__ __device__ float warp_prefix_sum(const int i, const int fn, const pix
 
 	#pragma unroll
 	for (int j = 1; j <= WARP_SIZE; j *= 2) {
-		float n = __shfl_up_sync(0xFFFFFFFF, cost, j);
+		#if (__CUDA_ARCH__ < 700)
+			float n = __shfl_up(cost, j);
+		#else
+			float n = __shfl_up_sync(0xFFFFFFFF, cost, j);
+		#endif
 
 		if (lane >= j) cost += n;
 	}
 
 	s_data[i+lane+1] = cost;
 
-	return __shfl_sync(0xFFFFFFFF, cost, WARP_SIZE-1);
+	#if (__CUDA_ARCH__ < 700)
+		return __shfl(cost, WARP_SIZE-1);
+	#else
+		return __shfl_sync(0xFFFFFFFF, cost, WARP_SIZE-1);
+	#endif
 }
 
 __inline__ __device__ void ComputePrefixSumWarp2(const int fn, const pixel_t* __restrict__ d_disparity,

--- a/util.h
+++ b/util.h
@@ -104,7 +104,7 @@ __inline__ __device__ int shfl_32(int scalarValue, const int lane) {
 	#if FERMI
 		return __emulated_shfl(scalarValue, (uint32_t)lane);
 	#else
-		return __shfl(scalarValue, lane);
+		return __shfl_sync(0xFFFFFFFF, scalarValue, lane);
 	#endif
 }
 
@@ -114,7 +114,7 @@ __inline__ __device__ int shfl_up_32(int scalarValue, const int n) {
 		lane -= n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_up(scalarValue, n);
+		return __shfl_up_sync(0xFFFFFFFF, scalarValue, n);
 	#endif
 }
 
@@ -124,7 +124,7 @@ __inline__ __device__ int shfl_down_32(int scalarValue, const int n) {
 		lane += n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_down(scalarValue, n);
+		return __shfl_down_sync(0xFFFFFFFF, scalarValue, n);
 	#endif
 }
 
@@ -134,7 +134,7 @@ __inline__ __device__ int shfl_xor_32(int scalarValue, const int n) {
 		lane = lane ^ n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_xor(scalarValue, n);
+		return __shfl_xor_sync(0xFFFFFFFF, scalarValue, n);
 	#endif
 }
 
@@ -438,7 +438,7 @@ __inline__ __device__ bool blockAny(bool local_condition) {
 	const int lane = threadIdx.x % WARP_SIZE;
 	const int wid = threadIdx.x / WARP_SIZE;
 
-	local_condition = __any(local_condition);     // Each warp performs __any
+	local_condition = __any_sync(0xFFFFFFFF, local_condition);     // Each warp performs __any
 
 	if (lane==0) {
 		conditions[wid]=local_condition;
@@ -450,7 +450,7 @@ __inline__ __device__ bool blockAny(bool local_condition) {
 	local_condition = (threadIdx.x < blockDim.x / WARP_SIZE) ? conditions[lane] : false;
 
 	if (wid==0) {
-		local_condition = __any(local_condition); //Final __any within first warp
+		local_condition = __any_sync(0xFFFFFFFF, local_condition); //Final __any within first warp
 	}
 
 	return local_condition;


### PR DESCRIPTION
Hi!

Thanks for publishing your Stixel code! Unfortunately, when using it with CUDA 9.1 on a Volta card, I ran into some problems.

1. I replaced `__shfl*` and `__any` calls with the new `*_sync` equivalents to compile it for arch=70 and sm=70.
2. When using `cuda-memcheck` I was able to spot a couple of illegal memory accesses (see lines 106 in Stixels.cu, 310 and 349 in StixelsKernels.cu). These were not visible to cuda-memcheck before CUDA 9.0 (out of bound memory access).

It would be great if you could double check the fixes. 

Also, regarding line 106 in Stixels.cu:
According to figure 4 in your paper on arxiv (https://arxiv.org/pdf/1610.04124.pdf), I think it should actually be `(rows_power2+1)*m_realcols*m_max_dis*sizeof(float)`. However, from what I have seen it is ensured that rows_power2 always satisfies `rows <= rows_power2 - 1`. Therefore, I the code was fine as it was before, except for the last element in `d_object_lut`. Thus, I added only one more float to the array.

Sometimes obj_fni is slightly negative O(1e-5), which results in `floor` to evaluate to `-1` producing an illegal memory access. This means that in the prefix sum, there is a value which is larger that its predecessor. As all entries in `sum` are positive (disparities), this should not happen (I checked this.). I think this an numeric issue of the `ComputePrefixSum` sum.
However, this also means that `ground_lut` and `sky_lut` might suffer from the same problem.

Best,
Thomas